### PR TITLE
Solve Validation Errors for Quizzify

### DIFF
--- a/app/features/quizzify/tools.py
+++ b/app/features/quizzify/tools.py
@@ -43,6 +43,20 @@ def transform_json_dict(input_data: dict) -> dict:
 
     return transformed_data
 
+def has_properties_key(dictionary):
+    """
+    Check if the given dictionary has a 'properties' key.
+    
+    Parameters:
+    dictionary (dict): The dictionary to check.
+    
+    Returns:
+    bool: True if the dictionary has a 'properties' key, False otherwise.
+    """
+    if isinstance(dictionary, dict):
+        return 'properties' in dictionary
+    return False
+
 def read_text_file(file_path):
     # Get the directory containing the script file
     script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -338,18 +352,24 @@ class QuizBuilder:
             if self.verbose:
                 logger.info(f"Generated response attempt {attempts + 1}: {response}")
 
-            response = transform_json_dict(response)
-            # Directly check if the response format is valid
-            if self.validate_response(response):
-                response["choices"] = self.format_choices(response["choices"])
-                generated_questions.append(response)
-                if self.verbose:
-                    logger.info(f"Valid question added: {response}")
-                    logger.info(f"Total generated questions: {len(generated_questions)}")
+            appropriate_result = has_properties_key(response)
+
+            if(not appropriate_result):
+                response = transform_json_dict(response)
+                # Directly check if the response format is valid
+                if self.validate_response(response):
+                    response["choices"] = self.format_choices(response["choices"])
+                    generated_questions.append(response)
+                    if self.verbose:
+                        logger.info(f"Valid question added: {response}")
+                        logger.info(f"Total generated questions: {len(generated_questions)}")
+                else:
+                    if self.verbose:
+                        logger.warning(f"Invalid response format. Attempt {attempts + 1} of {max_attempts}")
             else:
                 if self.verbose:
                     logger.warning(f"Invalid response format. Attempt {attempts + 1} of {max_attempts}")
-            
+
             # Move to the next attempt regardless of success to ensure progress
             attempts += 1
 

--- a/app/features/quizzify/tools.py
+++ b/app/features/quizzify/tools.py
@@ -43,20 +43,6 @@ def transform_json_dict(input_data: dict) -> dict:
 
     return transformed_data
 
-def has_properties_key(dictionary):
-    """
-    Check if the given dictionary has a 'properties' key.
-    
-    Parameters:
-    dictionary (dict): The dictionary to check.
-    
-    Returns:
-    bool: True if the dictionary has a 'properties' key, False otherwise.
-    """
-    if isinstance(dictionary, dict):
-        return 'properties' in dictionary
-    return False
-
 def read_text_file(file_path):
     # Get the directory containing the script file
     script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -352,9 +338,7 @@ class QuizBuilder:
             if self.verbose:
                 logger.info(f"Generated response attempt {attempts + 1}: {response}")
 
-            appropriate_result = has_properties_key(response)
-
-            if(not appropriate_result):
+            if(not 'properties' in response):
                 response = transform_json_dict(response)
                 # Directly check if the response format is valid
                 if self.validate_response(response):


### PR DESCRIPTION
This PR is made for solving Issue #48.
What I've discovered in my research of this problem was that a malformed JSON was made when the number of chunks was generally bigger. For example, I've found this for the actual details that @mikhailocampo provided:
![image](https://github.com/radicalxdev/kai-ai-backend/assets/113047749/0fbf9476-0440-4f20-b4fd-4be44d9f2dd1)
![image](https://github.com/radicalxdev/kai-ai-backend/assets/113047749/87af277c-a390-4f6e-bf2e-88b5a8f21ec7)
I've also tested them with the following files and found the same problem:
https://hagan.okstate.edu/NNDesign.pdf with the topic "Neural Networks"
![image](https://github.com/radicalxdev/kai-ai-backend/assets/113047749/0072e0ad-021a-45b6-93d8-4dd1ea8673f4)
https://diposit.ub.edu/dspace/bitstream/2445/180441/2/tfm_lichtner_bajjaoui_aisha.pdf
![image](https://github.com/radicalxdev/kai-ai-backend/assets/113047749/8510efbb-d599-4452-95b9-6444f07812a0)
So, I've discovered that the malformed JSON had a "properties" key in its composition, making it unappropriate for the actual Pydantic Schema. So, I developed a function to test if the response has that. If so, then it will re-try to generate another question, providing appropriate results with bigger PDF files.
![image](https://github.com/radicalxdev/kai-ai-backend/assets/113047749/2ca1f40c-b7a3-4c1e-bcc5-9a021ea54311)
![image](https://github.com/radicalxdev/kai-ai-backend/assets/113047749/c824daf6-c310-41b0-b366-30a01a34a0d3)
![image](https://github.com/radicalxdev/kai-ai-backend/assets/113047749/c5ec0983-7a38-4c6a-b601-c0d9d17f0795)
